### PR TITLE
Mirror of antlr antlr4#2864

### DIFF
--- a/runtime/JavaScript/src/antlr4/Utils.js
+++ b/runtime/JavaScript/src/antlr4/Utils.js
@@ -66,11 +66,11 @@ String.prototype.hashCode = function () {
 };
 
 function standardEqualsFunction(a, b) {
-    return a.equals(b);
+    return a ? a.equals(b) : a==b;
 }
 
 function standardHashCodeFunction(a) {
-    return a.hashCode();
+    return a ? a.hashCode() : -1;
 }
 
 class Set {


### PR DESCRIPTION
Mirror of antlr antlr4#2864
<at>parrt 
bumped into this bug with the JS runtime, caused I suspect by a bug which may affect all targets.

The root cause would come from PredictionContext.merge, lines 169 and 172, where an ArrayPredictionContext is created from a SingletonPredictionContext, which is some cases is an EmptyPredictionContext, with a null parent.
This translates into ArrayPredictionContext.parents being initialized to { null }, which is a nasty code smell...

I'll happily fix it if you think it makes sense, just let me know.
